### PR TITLE
Updated deprecated usage of plistlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from plistlib import Plist
+import plistlib
 
 try:
     from setuptools import setup
@@ -21,7 +21,8 @@ assets into a Snipe-IT database.
 '''
 
 try:
-    plist = Plist.fromFile('Info.plist')
+    with open('Info.plist', 'rb') as plist_file:
+        plist = plistlib.load(plist_file)
     plist.update(dict(
             CFBundleVersion=__version__,
             CFBundleShortVersionString=__version__,


### PR DESCRIPTION
Usage of `plistlib.Plist` has been deprecated for years and has been finally removed from python 3.7's `plistlib` package. Trying to execute `python setup.py` in 3.7 resulted in the following error:

> cannot import name 'Plist' from 'plistlib'

Using the `plistlib.load` function is the [recommended way](https://github.com/python/cpython/blob/v3.6.6/Lib/plistlib.py#L139).

From python 3.7 [changelog](https://docs.python.org/3/whatsnew/3.7.html#api-and-feature-removals):

> Removed previously deprecated in Python 2.4 classes Plist [...] in the plistlib module.