### PR TITLE
Pep8 pylint fixes

### DIFF
--- a/inqry/form_instructions.py
+++ b/inqry/form_instructions.py
@@ -32,9 +32,10 @@ class FormInstructions:
 
     def new_asset(self, asset_tag, user, form_type) -> str:
         status = 'Ready'
-        return barcode.textify(asset_tag) + barcode.listify(self.model_identifier) + self.get_asset_sequence(
-            form_type) + barcode.listify(status) + self.get_user_sequence(user) + barcode.delayify(
-            self.serial_number)
+        return (
+            barcode.textify(asset_tag) + barcode.listify(self.model_identifier) + self.get_asset_sequence(form_type)
+            + barcode.listify(status) + self.get_user_sequence(user) + barcode.delayify(self.serial_number)
+        )
 
     def new_model(self) -> str:
         return barcode.textify(self.model_name) + barcode.tabify(2) + barcode.delayify(

--- a/inqry/form_instructions.py
+++ b/inqry/form_instructions.py
@@ -10,7 +10,7 @@ class FormInstructions:
                                        specs.drive1, specs.drive2,
                                        specs.drive3, specs.drive4],
                            'Portable': [self.processor, specs.memory,
-                                       specs.drive1]}
+                                        specs.drive1]}
 
         self.model_identifier = specs.model_identifier
         self.model_name = specs.model_name

--- a/inqry/gui.py
+++ b/inqry/gui.py
@@ -74,18 +74,18 @@ class InQRyGUI:  # TODO: Extract GUI attributes to methods
     def gather_user_input(self) -> tuple:
         if self.qrcode_selection.get() == 'New Model':
             return self.qrcode_selection.get(), None, None, self.form_selection.get()
-        else:
-            return self.qrcode_selection.get(), self.get_asset_tag(), self.get_alias(), self.form_selection.get()
+
+        return self.qrcode_selection.get(), self.get_asset_tag(), self.get_alias(), self.form_selection.get()
 
     def _validate_field_contents(self, contents, field):
         patterns = {'Alias': re.compile(r'^(v\-)?[A-Za-z]+$'),
                     'Asset Tag': re.compile(r'^E?\d{7}$')}
         if bool(re.match(patterns[field], contents)):
             return contents
-        else:
-            error_message = '{} is not properly formatted.'.format(field)
-            error_message_box(error_message)
-            raise ValueError(error_message)
+
+        error_message = '{} is not properly formatted.'.format(field)
+        error_message_box(error_message)
+        raise ValueError(error_message)
 
     def get_alias(self):
         return self._validate_field_contents(self.alias_entry.get(), 'Alias')

--- a/inqry/gui.py
+++ b/inqry/gui.py
@@ -121,12 +121,13 @@ def mobile_capability():  # TODO: Re-implement mobile_capability() into GUI
             return 'active'
         except FileNotFoundError:
             print(
-                    '''
-                    No such file or directory: "/usr/local/bin/cfgutil"
+                '''
+                No such file or directory: "/usr/local/bin/cfgutil"
 
-                    You must install cfgutil using Apple Configurator in order to
-                    use InQRy with a mobile device.
-                    ''')
+                You must install cfgutil using Apple Configurator in order to
+                use InQRy with a mobile device.
+                '''
+            )
             return 'disable'
     else:
         pass

--- a/inqry/system_specs/__init__.py
+++ b/inqry/system_specs/__init__.py
@@ -16,5 +16,5 @@ def _human_readable(component):
     size = round(int(component) / 10 ** 9)
     if size >= 1000:
         return str(size / 1000) + " TB"
-    else:
-        return str(size) + " GB"
+
+    return str(size) + " GB"

--- a/inqry/system_specs/windisk.py
+++ b/inqry/system_specs/windisk.py
@@ -59,5 +59,5 @@ class Disk(object):
         size = round(int(component) / 10 ** 9)
         if size >= 1000:
             return str(size / 1000) + " TB"
-        else:
-            return str(size) + " GB"
+
+        return str(size) + " GB"

--- a/setup.py
+++ b/setup.py
@@ -24,41 +24,45 @@ try:
     with open('Info.plist', 'rb') as plist_file:
         plist = plistlib.load(plist_file)
     plist.update(dict(
-            CFBundleVersion=__version__,
-            CFBundleShortVersionString=__version__,
-            CFBundleName='InQRy',
-            NSHumanReadableCopyright=__copyright__))
+        CFBundleVersion=__version__,
+        CFBundleShortVersionString=__version__,
+        CFBundleName='InQRy',
+        NSHumanReadableCopyright=__copyright__
+    ))
 except FileNotFoundError:
     plist = None
 
 setup(
-        name='inqry',
-        app=['inqry/__main__.py'],
-        author=[__author__],
-        author_email=__email__,
-        description='A cross-platform utility used to generate a QR code containing hardware specs',
-        license=__license__,
-        long_description=__description__,
-        packages=['inqry', 'inqry.system_specs'],
-        install_requires=['Pillow',
-                          'pytest',
-                          'PyYAML',
-                          'qrcode',
-                          'wmi;platform_system=="Windows"',
-                          'pypiwin32;platform_system=="Windows"'],
-        tests_require=['pytest'],
-        url='https://github.com/Microsoft/InQRy',
-        version=__version__,
-        classifiers=[
-            'License :: OSI Approved :: MIT License',
-            'Natural Language :: English',
-            'Intended Audience :: Information Technology',
-            'Intended Audience :: System Administrators',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3 :: Only'],
-        options=dict(
-                py2app=dict(
-                        plist=plist)))
+    name='inqry',
+    app=['inqry/__main__.py'],
+    author=[__author__],
+    author_email=__email__,
+    description='A cross-platform utility used to generate a QR code containing hardware specs',
+    license=__license__,
+    long_description=__description__,
+    packages=['inqry', 'inqry.system_specs'],
+    install_requires=['Pillow',
+                      'pytest',
+                      'PyYAML',
+                      'qrcode',
+                      'wmi;platform_system=="Windows"',
+                      'pypiwin32;platform_system=="Windows"'],
+    tests_require=['pytest'],
+    url='https://github.com/Microsoft/InQRy',
+    version=__version__,
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only'],
+    options=dict(
+        py2app=dict(
+            plist=plist
+        )
+    )
+)

--- a/tests/generic/test_form_instructions.py
+++ b/tests/generic/test_form_instructions.py
@@ -11,6 +11,7 @@ def test_new_asset_method():
     assert instructions.new_asset('1234567', 'admin',
                                   'Desktop') == '~d1234567~d~t~d ~dMacPro6,1~d~e~d~t~d3.7 GHz Quad-Core Intel Xeon E5~d~t~d32 GB~d~t~d3.0 TB HDD (APPLE HDD ST3000DM001)~d~t~d121.3 GB SSD (APPLE SSD SM0128G)~d~t~d~t~d~t~d ~dReady~d~e~d~t~d ~d(admin)~d~e~d~t~dF5KQH0P9F9VN'
 
+
 def test_new_model_method():
     instructions = form_instructions.FormInstructions(MAC_SYSTEM_SPECS)
     assert instructions.new_model() == '~dMac Pro~d~t~t~t~dMacPro6,1'

--- a/tests/ios/cfgutil/test_parsing_cfgutil_output_iphone.py
+++ b/tests/ios/cfgutil/test_parsing_cfgutil_output_iphone.py
@@ -2,7 +2,7 @@ from inqry.system_specs import cfgutil
 
 CFGUTIL_OUTPUT = '''
 {"Command":"get","Output":{"0xA64D620D30D26":{"serialNumber":"F71SHPP0HG6W", "totalDiskCapacity":32000000000,
-"deviceType":"iPhone9,1","IMEI":"359167076630320","color":"1"},"Errors":{"0xA64D620D30D26":{}}}, 
+"deviceType":"iPhone9,1","IMEI":"359167076630320","color":"1"},"Errors":{"0xA64D620D30D26":{}}},
 "Type":"CommandOutput","Devices":["0xA64D620D30D26"]}
 '''
 

--- a/tests/mac/diskutil/test_getting_identifiers_disk_images.py
+++ b/tests/mac/diskutil/test_getting_identifiers_disk_images.py
@@ -50,7 +50,7 @@ DISKUTIL_LIST_OUTPUT = '''
    1:                        EFI EFI                     209.7 MB   disk7s1
    2:                 Apple_RAID                         999.9 GB   disk7s2
    3:                 Apple_Boot Boot OS X               134.2 MB   disk7s3
-   
+
 /dev/disk8 (external, virtual):
    #:                       TYPE NAME                    SIZE       IDENTIFIER
    0:                  Apple_HFS RedBackup              +2.0 TB     disk8

--- a/tests/windows/windisk/test_representing_surface_ssd_storage.py
+++ b/tests/windows/windisk/test_representing_surface_ssd_storage.py
@@ -27,7 +27,7 @@ Model                            : SAMSUNG MZFLV256HCHP-000MV
 OperationalDetails               :
 PhysicalLocation                 : PCI Slot 4 : Adapter 0
 SerialNumber                     : 0025_3841_61B6_798A.
-AdapterSerialNumber              : S245NXCH108281      
+AdapterSerialNumber              : S245NXCH108281
 AllocatedSize                    : 256060514304
 CanPool                          : False
 DeviceId                         : 0

--- a/tests/windows/windisk/test_representing_surface_ssd_storage.py
+++ b/tests/windows/windisk/test_representing_surface_ssd_storage.py
@@ -15,35 +15,35 @@ SpindleSpeed                     : 0
 ObjectId                         : {1}\\MININT-MSGHJGV\root/Microsoft/Windows/Storage/Providers_v2
 \SPACES_PhysicalDisk.ObjectId="{7869a9f6-d79a-11e6-84dd-806e6f6e6963}:PD:{ed172607-d72a-1b5a-f
                                    367-403fe45ca8d5}"
-PassThroughClass                 : 
-PassThroughIds                   : 
-PassThroughNamespace             : 
-PassThroughServer                : 
+PassThroughClass                 :
+PassThroughIds                   :
+PassThroughNamespace             :
+PassThroughServer                :
 UniqueId                         : eui.0025384161B6798A
-Description                      : 
+Description                      :
 FriendlyName                     : SAMSUNG MZFLV256HCHP-000MV
-Manufacturer                     : 
+Manufacturer                     :
 Model                            : SAMSUNG MZFLV256HCHP-000MV
-OperationalDetails               : 
+OperationalDetails               :
 PhysicalLocation                 : PCI Slot 4 : Adapter 0
 SerialNumber                     : 0025_3841_61B6_798A.
 AdapterSerialNumber              : S245NXCH108281      
 AllocatedSize                    : 256060514304
 CanPool                          : False
 DeviceId                         : 0
-EnclosureNumber                  : 
+EnclosureNumber                  :
 FirmwareVersion                  : BXV75M0Q
-IsIndicationEnabled              : 
+IsIndicationEnabled              :
 IsPartial                        : True
 LogicalSectorSize                : 512
-OtherCannotPoolReasonDescription : 
-PartNumber                       : 
+OtherCannotPoolReasonDescription :
+PartNumber                       :
 PhysicalSectorSize               : 512
 Size                             : 256060514304
-SlotNumber                       : 
-SoftwareVersion                  : 
+SlotNumber                       :
+SoftwareVersion                  :
 VirtualDiskFootprint             : 0
-PSComputerName                   : 
+PSComputerName                   :
 CimClass                         : root/microsoft/windows/storage:MSFT_PhysicalDisk
 CimInstanceProperties            : {ObjectId, PassThroughClass, PassThroughIds, PassThroughNamespace...}
 CimSystemProperties              : Microsoft.Management.Infrastructure.CimSystemProperties


### PR DESCRIPTION
PEP8 Fixes:
* E126, E128: Over/Under-Indentation
* W291: Trailing whitespace
* W293: Whitespace on blank line
* E302: Too few blank lines

PyLint fixes:
* no-else-return: Unnecessary else clauses
* bad-continuation: Wrong indentation