### PR TITLE
Fix crash on no processor speed available

### DIFF
--- a/inqry/system_specs/windows_system_profiler.py
+++ b/inqry/system_specs/windows_system_profiler.py
@@ -59,7 +59,10 @@ class WindowsProfile:
 
     @staticmethod
     def get_processor_speed(full_processor_name):
-        return WindowsProfile._split_processor(full_processor_name)[1]
+        try:
+            return WindowsProfile._split_processor(full_processor_name)[1]
+        except IndexError:
+            return ''
 
     @staticmethod
     def get_memory_in_gigabytes(memory_bytes):


### PR DESCRIPTION
Simply handles the case of no speed available by returning an empty string.